### PR TITLE
devtools::install_github

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then, install directly from this repo:
 library(httr)
 library(devtools)
 set_config( config( ssl_verifypeer = 0L ) )
-install_github('us-bea/beaR')
+devtools::install_github('us-bea/beaR')
 ```
 
 ##Call the library


### PR DESCRIPTION
Added 'devtools' to the install line. After testing a few times, this seems to improve the chances of dependencies being installed.